### PR TITLE
📔 jjeong - 1주차 과제 MVC(인증)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-logging'
 
+
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,8 @@ dependencies {
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test:3.4.4'
     testImplementation 'io.rest-assured:rest-assured:5.5.1'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.12.1'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.10.1'
 
     implementation 'org.springframework.boot:spring-boot-starter-logging'
 

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,9 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test:3.4.4'
     testImplementation 'io.rest-assured:rest-assured:5.5.1'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.12.1'
+
+    implementation 'org.springframework.boot:spring-boot-starter-logging'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/yourssu/roomescape/config/WebConfig.java
+++ b/src/main/java/com/yourssu/roomescape/config/WebConfig.java
@@ -1,8 +1,10 @@
 package com.yourssu.roomescape.config;
 
 import com.yourssu.roomescape.member.LoginMemberArgumentResolver;
+import com.yourssu.roomescape.member.MemberRoleHandlerInterceptor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import java.util.List;
@@ -11,13 +13,22 @@ import java.util.List;
 public class WebConfig implements WebMvcConfigurer {
 
     private LoginMemberArgumentResolver loginMemberArgumentResolver;
+    private MemberRoleHandlerInterceptor memberRoleHandlerInterceptor;
 
-    public WebConfig(LoginMemberArgumentResolver loginMemberArgumentResolver) {
+    public WebConfig(LoginMemberArgumentResolver loginMemberArgumentResolver, MemberRoleHandlerInterceptor memberRoleHandlerInterceptor) {
         this.loginMemberArgumentResolver = loginMemberArgumentResolver;
+        this.memberRoleHandlerInterceptor = memberRoleHandlerInterceptor;
     }
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(loginMemberArgumentResolver);
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+
+        registry.addInterceptor(memberRoleHandlerInterceptor)
+                .addPathPatterns("/admin/**");
     }
 }

--- a/src/main/java/com/yourssu/roomescape/config/WebConfig.java
+++ b/src/main/java/com/yourssu/roomescape/config/WebConfig.java
@@ -1,0 +1,23 @@
+package com.yourssu.roomescape.config;
+
+import com.yourssu.roomescape.member.LoginMemberArgumentResolver;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    private LoginMemberArgumentResolver loginMemberArgumentResolver;
+
+    public WebConfig(LoginMemberArgumentResolver loginMemberArgumentResolver) {
+        this.loginMemberArgumentResolver = loginMemberArgumentResolver;
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(loginMemberArgumentResolver);
+    }
+}

--- a/src/main/java/com/yourssu/roomescape/exception/ExceptionMessage.java
+++ b/src/main/java/com/yourssu/roomescape/exception/ExceptionMessage.java
@@ -3,7 +3,6 @@ package com.yourssu.roomescape.exception;
 public enum ExceptionMessage {
 
     NO_EXIST_MEMBER("멤버가 존재하지 않습니다.");
-
     private final String message;
 
     ExceptionMessage(String message) {

--- a/src/main/java/com/yourssu/roomescape/exception/ExceptionMessage.java
+++ b/src/main/java/com/yourssu/roomescape/exception/ExceptionMessage.java
@@ -1,0 +1,16 @@
+package com.yourssu.roomescape.exception;
+
+public enum ExceptionMessage {
+
+    NO_EXIST_MEMBER("멤버가 존재하지 않습니다.");
+
+    private final String message;
+
+    ExceptionMessage(String message) {
+        this.message = message;
+    }
+
+    public String getMessage(){
+        return message;
+    }
+}

--- a/src/main/java/com/yourssu/roomescape/member/LoginMember.java
+++ b/src/main/java/com/yourssu/roomescape/member/LoginMember.java
@@ -4,13 +4,11 @@ public class LoginMember {
     private Long id;
     private String name;
     private String email;
-    private String role;
 
-    public LoginMember(Long id, String name, String email, String role) {
+    public LoginMember(Long id, String name, String email) {
         this.id = id;
         this.name = name;
         this.email = email;
-        this.role = role;
     }
 
     public Long getId() {
@@ -25,7 +23,4 @@ public class LoginMember {
         return email;
     }
 
-    public String getRole() {
-        return role;
-    }
 }

--- a/src/main/java/com/yourssu/roomescape/member/LoginMember.java
+++ b/src/main/java/com/yourssu/roomescape/member/LoginMember.java
@@ -1,0 +1,31 @@
+package com.yourssu.roomescape.member;
+
+public class LoginMember {
+    private Long id;
+    private String name;
+    private String email;
+    private String role;
+
+    public LoginMember(Long id, String name, String email, String role) {
+        this.id = id;
+        this.name = name;
+        this.email = email;
+        this.role = role;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getRole() {
+        return role;
+    }
+}

--- a/src/main/java/com/yourssu/roomescape/member/LoginMember.java
+++ b/src/main/java/com/yourssu/roomescape/member/LoginMember.java
@@ -4,11 +4,13 @@ public class LoginMember {
     private Long id;
     private String name;
     private String email;
+    private String role;
 
-    public LoginMember(Long id, String name, String email) {
+    public LoginMember(Long id, String name, String email, String role) {
         this.id = id;
         this.name = name;
         this.email = email;
+        this.role = role;
     }
 
     public Long getId() {
@@ -22,5 +24,7 @@ public class LoginMember {
     public String getEmail() {
         return email;
     }
+
+    public String getRole(){return role;}
 
 }

--- a/src/main/java/com/yourssu/roomescape/member/LoginMemberArgumentResolver.java
+++ b/src/main/java/com/yourssu/roomescape/member/LoginMemberArgumentResolver.java
@@ -15,7 +15,6 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolver {
     private MemberService memberService;
     private final TokenUtil tokenUtil = new TokenUtil();
-    private MemberDao memberDao;
 
     public LoginMemberArgumentResolver(MemberService memberService) {
         this.memberService = memberService;
@@ -32,9 +31,8 @@ public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolve
         Cookie[] cookies = request.getCookies();
 
         String token = tokenUtil.extractTokenFromCookie(cookies);
-        Long memberId = tokenUtil.parseTokenToId(token);
-        Member member = memberDao.findById(memberId);
+        MemberResponse member = memberService.checkLogin(token);
 
-        return new LoginMember(member.getId(), member.getName(), member.getEmail(), member.getRole());
+        return new LoginMember(member.getId(), member.getName(), member.getEmail());
     }
 }

--- a/src/main/java/com/yourssu/roomescape/member/LoginMemberArgumentResolver.java
+++ b/src/main/java/com/yourssu/roomescape/member/LoginMemberArgumentResolver.java
@@ -14,10 +14,11 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 @Component
 public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolver {
     private MemberService memberService;
-    private final TokenUtil tokenUtil = new TokenUtil();
+    private final TokenUtil tokenUtil;
 
-    public LoginMemberArgumentResolver(MemberService memberService) {
+    public LoginMemberArgumentResolver(MemberService memberService, TokenUtil tokenUtil) {
         this.memberService = memberService;
+        this.tokenUtil = tokenUtil;
     }
 
     @Override

--- a/src/main/java/com/yourssu/roomescape/member/LoginMemberArgumentResolver.java
+++ b/src/main/java/com/yourssu/roomescape/member/LoginMemberArgumentResolver.java
@@ -33,6 +33,6 @@ public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolve
         String token = tokenUtil.extractTokenFromCookie(cookies);
         MemberResponse member = memberService.checkLogin(token);
 
-        return new LoginMember(member.getId(), member.getName(), member.getEmail());
+        return new LoginMember(member.getId(), member.getName(), member.getEmail(), member.getRole());
     }
 }

--- a/src/main/java/com/yourssu/roomescape/member/LoginMemberArgumentResolver.java
+++ b/src/main/java/com/yourssu/roomescape/member/LoginMemberArgumentResolver.java
@@ -1,0 +1,38 @@
+package com.yourssu.roomescape.member;
+
+import com.yourssu.roomescape.utils.TokenUtil;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolver {
+    private MemberService memberService;
+    private final TokenUtil tokenUtil = new TokenUtil();
+    private MemberDao memberDao;
+
+    public LoginMemberArgumentResolver(MemberService memberService) {
+        this.memberService = memberService;
+    }
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterType().equals(LoginMember.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+        Cookie[] cookies = request.getCookies();
+
+        String token = tokenUtil.extractTokenFromCookie(cookies);
+        Long memberId = tokenUtil.parseTokenToId(token);
+        Member member = memberDao.findById(memberId);
+
+        return new LoginMember(member.getId(), member.getName(), member.getEmail(), member.getRole());
+    }
+}

--- a/src/main/java/com/yourssu/roomescape/member/LoginMemberArgumentResolver.java
+++ b/src/main/java/com/yourssu/roomescape/member/LoginMemberArgumentResolver.java
@@ -4,12 +4,14 @@ import com.yourssu.roomescape.utils.TokenUtil;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.context.request.ServletWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
+@Component
 public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolver {
     private MemberService memberService;
     private final TokenUtil tokenUtil = new TokenUtil();

--- a/src/main/java/com/yourssu/roomescape/member/LoginPostRequest.java
+++ b/src/main/java/com/yourssu/roomescape/member/LoginPostRequest.java
@@ -1,0 +1,14 @@
+package com.yourssu.roomescape.member;
+
+public class LoginPostRequest {
+    private String email;
+    private String password;
+
+    public String getPassword() {
+        return password;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+}

--- a/src/main/java/com/yourssu/roomescape/member/MemberController.java
+++ b/src/main/java/com/yourssu/roomescape/member/MemberController.java
@@ -46,5 +46,8 @@ public class MemberController {
         return ResponseEntity.ok().build();
     }
 
+    @GetMapping("/login/check")
+    public ResponseEntity checkLogin()
+
 
 }

--- a/src/main/java/com/yourssu/roomescape/member/MemberController.java
+++ b/src/main/java/com/yourssu/roomescape/member/MemberController.java
@@ -15,10 +15,11 @@ import java.net.URI;
 @RestController
 public class MemberController {
     private MemberService memberService;
-    private final TokenUtil tokenUtil = new TokenUtil();
+    private final TokenUtil tokenUtil;
 
-    public MemberController(MemberService memberService) {
+    public MemberController(MemberService memberService, TokenUtil tokenUtil) {
         this.memberService = memberService;
+        this.tokenUtil = tokenUtil;
     }
 
     @PostMapping("/members")

--- a/src/main/java/com/yourssu/roomescape/member/MemberController.java
+++ b/src/main/java/com/yourssu/roomescape/member/MemberController.java
@@ -1,6 +1,8 @@
 package com.yourssu.roomescape.member;
 
+import com.yourssu.roomescape.utils.TokenUtil;
 import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -13,6 +15,7 @@ import java.net.URI;
 @RestController
 public class MemberController {
     private MemberService memberService;
+    private final TokenUtil tokenUtil = new TokenUtil();
 
     public MemberController(MemberService memberService) {
         this.memberService = memberService;
@@ -47,7 +50,13 @@ public class MemberController {
     }
 
     @GetMapping("/login/check")
-    public ResponseEntity checkLogin()
-
-
+    public ResponseEntity<MemberResponse> checkLogin(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        String token = tokenUtil.extractTokenFromCookie(cookies);
+        if (token != null){
+            MemberResponse response = memberService.checkLogin(token);
+            return ResponseEntity.ok(response);
+        }
+        return null;
+    }
 }

--- a/src/main/java/com/yourssu/roomescape/member/MemberController.java
+++ b/src/main/java/com/yourssu/roomescape/member/MemberController.java
@@ -3,6 +3,7 @@ package com.yourssu.roomescape.member;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -32,4 +33,18 @@ public class MemberController {
         response.addCookie(cookie);
         return ResponseEntity.ok().build();
     }
+
+    @PostMapping("/login")
+    public ResponseEntity login(@RequestBody LoginPostRequest request, HttpServletResponse response){
+        String jwtToken = memberService.login(request);
+
+        Cookie cookie = new Cookie("token", jwtToken);
+        cookie.setHttpOnly(true);
+        cookie.setPath("/");
+        response.addCookie(cookie);
+
+        return ResponseEntity.ok().build();
+    }
+
+
 }

--- a/src/main/java/com/yourssu/roomescape/member/MemberDao.java
+++ b/src/main/java/com/yourssu/roomescape/member/MemberDao.java
@@ -52,4 +52,17 @@ public class MemberDao {
                 name
         );
     }
+
+    public Member findById(Long memberId){
+        return jdbcTemplate.queryForObject(
+                "SELECT id, name, email, role FROM member WHERE id = ?",
+                (rs, rowNum) -> new Member(
+                        rs.getLong("id"),
+                        rs.getString("name"),
+                        rs.getString("email"),
+                        rs.getString("role")
+                ),
+                memberId
+        );
+    }
 }

--- a/src/main/java/com/yourssu/roomescape/member/MemberResponse.java
+++ b/src/main/java/com/yourssu/roomescape/member/MemberResponse.java
@@ -4,11 +4,13 @@ public class MemberResponse {
     private Long id;
     private String name;
     private String email;
+    private String role;
 
-    public MemberResponse(Long id, String name, String email) {
+    public MemberResponse(Long id, String name, String email, String role) {
         this.id = id;
         this.name = name;
         this.email = email;
+        this.role = role;
     }
 
     public Long getId() {
@@ -21,5 +23,9 @@ public class MemberResponse {
 
     public String getEmail() {
         return email;
+    }
+
+    public String getRole(){
+        return role;
     }
 }

--- a/src/main/java/com/yourssu/roomescape/member/MemberRoleHandlerInterceptor.java
+++ b/src/main/java/com/yourssu/roomescape/member/MemberRoleHandlerInterceptor.java
@@ -1,0 +1,35 @@
+package com.yourssu.roomescape.member;
+
+import com.yourssu.roomescape.utils.TokenUtil;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+public class MemberRoleHandlerInterceptor implements HandlerInterceptor {
+
+    private MemberService memberService;
+    private final TokenUtil tokenUtil = new TokenUtil();
+
+    public MemberRoleHandlerInterceptor(MemberService memberService){
+        this.memberService = memberService;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+
+        Cookie[] cookies = request.getCookies();
+
+        String token = tokenUtil.extractTokenFromCookie(cookies);
+        MemberResponse member = memberService.checkLogin(token);
+
+        if (member == null || !member.getRole().equals("ADMIN")) {
+            response.setStatus(401);
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/com/yourssu/roomescape/member/MemberRoleHandlerInterceptor.java
+++ b/src/main/java/com/yourssu/roomescape/member/MemberRoleHandlerInterceptor.java
@@ -11,10 +11,11 @@ import org.springframework.web.servlet.HandlerInterceptor;
 public class MemberRoleHandlerInterceptor implements HandlerInterceptor {
 
     private MemberService memberService;
-    private final TokenUtil tokenUtil = new TokenUtil();
+    private final TokenUtil tokenUtil;
 
-    public MemberRoleHandlerInterceptor(MemberService memberService){
+    public MemberRoleHandlerInterceptor(MemberService memberService, TokenUtil tokenUtil){
         this.memberService = memberService;
+        this.tokenUtil = tokenUtil;
     }
 
     @Override

--- a/src/main/java/com/yourssu/roomescape/member/MemberService.java
+++ b/src/main/java/com/yourssu/roomescape/member/MemberService.java
@@ -1,5 +1,6 @@
 package com.yourssu.roomescape.member;
 
+import com.yourssu.roomescape.utils.TokenUtil;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import jakarta.servlet.http.HttpServletResponse;
@@ -10,6 +11,7 @@ import static com.yourssu.roomescape.exception.ExceptionMessage.NO_EXIST_MEMBER;
 @Service
 public class MemberService {
     private MemberDao memberDao;
+    private final TokenUtil tokenUtil = new TokenUtil();
 
     public MemberService(MemberDao memberDao) {
         this.memberDao = memberDao;
@@ -27,22 +29,12 @@ public class MemberService {
             throw new IllegalArgumentException(NO_EXIST_MEMBER.getMessage());
         }
 
-        String secretKey = "Yn2kjibddFAWtnPJ2AFlL8WXmohJMCvigQggaEypa5E=";
-        return Jwts.builder()
-                .setSubject(member.getId().toString())
-                .claim("name", member.getName())
-                .claim("role", member.getRole())
-                .signWith(Keys.hmacShaKeyFor(secretKey.getBytes()))
-                .compact();
+        return tokenUtil.createToken(member);
     }
 
     public MemberResponse checkLogin(String token){
 
-        Long memberId = Long.valueOf(Jwts.parser()
-                .verifyWith(Keys.hmacShaKeyFor("Yn2kjibddFAWtnPJ2AFlL8WXmohJMCvigQggaEypa5E=".getBytes()))
-                .build()
-                .parseSignedClaims(token)
-                .getBody().getSubject());
+        Long memberId = tokenUtil.parseTokenToId(token);
 
         Member findMember = memberDao.findById(memberId);
         return new MemberResponse(findMember.getId(), findMember.getName(), findMember.getEmail());

--- a/src/main/java/com/yourssu/roomescape/member/MemberService.java
+++ b/src/main/java/com/yourssu/roomescape/member/MemberService.java
@@ -1,6 +1,11 @@
 package com.yourssu.roomescape.member;
 
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.stereotype.Service;
+
+import static com.yourssu.roomescape.exception.ExceptionMessage.NO_EXIST_MEMBER;
 
 @Service
 public class MemberService {
@@ -13,5 +18,21 @@ public class MemberService {
     public MemberResponse createMember(MemberRequest memberRequest) {
         Member member = memberDao.save(new Member(memberRequest.getName(), memberRequest.getEmail(), memberRequest.getPassword(), "USER"));
         return new MemberResponse(member.getId(), member.getName(), member.getEmail());
+    }
+
+    public String login(LoginPostRequest request){
+        Member member = memberDao.findByEmailAndPassword(request.getEmail(), request.getPassword());
+
+        if (member == null){
+            throw new IllegalArgumentException(NO_EXIST_MEMBER.getMessage());
+        }
+
+        String secretKey = "Yn2kjibddFAWtnPJ2AFlL8WXmohJMCvigQggaEypa5E=";
+        return Jwts.builder()
+                .setSubject(member.getId().toString())
+                .claim("name", member.getName())
+                .claim("role", member.getRole())
+                .signWith(Keys.hmacShaKeyFor(secretKey.getBytes()))
+                .compact();
     }
 }

--- a/src/main/java/com/yourssu/roomescape/member/MemberService.java
+++ b/src/main/java/com/yourssu/roomescape/member/MemberService.java
@@ -35,4 +35,16 @@ public class MemberService {
                 .signWith(Keys.hmacShaKeyFor(secretKey.getBytes()))
                 .compact();
     }
+
+    public MemberResponse checkLogin(String token){
+
+        Long memberId = Long.valueOf(Jwts.parser()
+                .verifyWith(Keys.hmacShaKeyFor("Yn2kjibddFAWtnPJ2AFlL8WXmohJMCvigQggaEypa5E=".getBytes()))
+                .build()
+                .parseSignedClaims(token)
+                .getBody().getSubject());
+
+        Member findMember = memberDao.findById(memberId);
+        return new MemberResponse(findMember.getId(), findMember.getName(), findMember.getEmail());
+    }
 }

--- a/src/main/java/com/yourssu/roomescape/member/MemberService.java
+++ b/src/main/java/com/yourssu/roomescape/member/MemberService.java
@@ -1,6 +1,7 @@
 package com.yourssu.roomescape.member;
 
 import com.yourssu.roomescape.utils.TokenUtil;
+import com.yourssu.roomescape.validator.MemberValidator;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import jakarta.servlet.http.HttpServletResponse;
@@ -26,9 +27,7 @@ public class MemberService {
     public String login(LoginPostRequest request){
         Member member = memberDao.findByEmailAndPassword(request.getEmail(), request.getPassword());
 
-        if (member == null){
-            throw new IllegalArgumentException(NO_EXIST_MEMBER.getMessage());
-        }
+        MemberValidator.validateMemeber(member);
 
         return tokenUtil.createToken(member);
     }

--- a/src/main/java/com/yourssu/roomescape/member/MemberService.java
+++ b/src/main/java/com/yourssu/roomescape/member/MemberService.java
@@ -19,7 +19,7 @@ public class MemberService {
 
     public MemberResponse createMember(MemberRequest memberRequest) {
         Member member = memberDao.save(new Member(memberRequest.getName(), memberRequest.getEmail(), memberRequest.getPassword(), "USER"));
-        return new MemberResponse(member.getId(), member.getName(), member.getEmail());
+        return new MemberResponse(member.getId(), member.getName(), member.getEmail(), member.getRole());
     }
 
     public String login(LoginPostRequest request){
@@ -37,6 +37,6 @@ public class MemberService {
         Long memberId = tokenUtil.parseTokenToId(token);
 
         Member findMember = memberDao.findById(memberId);
-        return new MemberResponse(findMember.getId(), findMember.getName(), findMember.getEmail());
+        return new MemberResponse(findMember.getId(), findMember.getName(), findMember.getEmail(), findMember.getRole());
     }
 }

--- a/src/main/java/com/yourssu/roomescape/member/MemberService.java
+++ b/src/main/java/com/yourssu/roomescape/member/MemberService.java
@@ -11,10 +11,11 @@ import static com.yourssu.roomescape.exception.ExceptionMessage.NO_EXIST_MEMBER;
 @Service
 public class MemberService {
     private MemberDao memberDao;
-    private final TokenUtil tokenUtil = new TokenUtil();
+    private final TokenUtil tokenUtil;
 
-    public MemberService(MemberDao memberDao) {
+    public MemberService(MemberDao memberDao, TokenUtil tokenUtil) {
         this.memberDao = memberDao;
+        this.tokenUtil = tokenUtil;
     }
 
     public MemberResponse createMember(MemberRequest memberRequest) {

--- a/src/main/java/com/yourssu/roomescape/property/TokenProperty.java
+++ b/src/main/java/com/yourssu/roomescape/property/TokenProperty.java
@@ -1,0 +1,16 @@
+package com.yourssu.roomescape.property;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "roomescape.auth.jwt")
+public class TokenProperty {
+    private final String secret;
+
+    public TokenProperty(String secret){
+        this.secret = secret;
+    }
+
+    public String getSecretKey(){
+        return secret;
+    }
+}

--- a/src/main/java/com/yourssu/roomescape/property/TokenPropertyConfiguration.java
+++ b/src/main/java/com/yourssu/roomescape/property/TokenPropertyConfiguration.java
@@ -1,0 +1,10 @@
+package com.yourssu.roomescape.property;
+
+import org.apache.el.parser.Token;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties({TokenProperty.class})
+public class TokenPropertyConfiguration {
+}

--- a/src/main/java/com/yourssu/roomescape/reservation/ReservationController.java
+++ b/src/main/java/com/yourssu/roomescape/reservation/ReservationController.java
@@ -31,6 +31,7 @@ public class ReservationController {
         ReservationResponse reservation = reservationService.save(reservationRequest, member);
 
         return ResponseEntity.created(URI.create("/reservations/" + reservation.getId())).body(reservation);
+
     }
 
     @DeleteMapping("/reservations/{id}")

--- a/src/main/java/com/yourssu/roomescape/reservation/ReservationController.java
+++ b/src/main/java/com/yourssu/roomescape/reservation/ReservationController.java
@@ -23,13 +23,12 @@ public class ReservationController {
 
     @PostMapping("/reservations")
     public ResponseEntity create(@RequestBody ReservationRequest reservationRequest, LoginMember member) {
-        if (reservationRequest.getName() == null
-                || reservationRequest.getDate() == null
+        if (reservationRequest.getDate() == null
                 || reservationRequest.getTheme() == null
                 || reservationRequest.getTime() == null) {
             return ResponseEntity.badRequest().build();
         }
-        ReservationResponse reservation = reservationService.save(reservationRequest);
+        ReservationResponse reservation = reservationService.save(reservationRequest, member);
 
         return ResponseEntity.created(URI.create("/reservations/" + reservation.getId())).body(reservation);
     }

--- a/src/main/java/com/yourssu/roomescape/reservation/ReservationController.java
+++ b/src/main/java/com/yourssu/roomescape/reservation/ReservationController.java
@@ -1,5 +1,6 @@
 package com.yourssu.roomescape.reservation;
 
+import com.yourssu.roomescape.member.LoginMember;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -21,7 +22,7 @@ public class ReservationController {
     }
 
     @PostMapping("/reservations")
-    public ResponseEntity create(@RequestBody ReservationRequest reservationRequest) {
+    public ResponseEntity create(@RequestBody ReservationRequest reservationRequest, LoginMember member) {
         if (reservationRequest.getName() == null
                 || reservationRequest.getDate() == null
                 || reservationRequest.getTheme() == null

--- a/src/main/java/com/yourssu/roomescape/reservation/ReservationDao.java
+++ b/src/main/java/com/yourssu/roomescape/reservation/ReservationDao.java
@@ -1,5 +1,6 @@
 package com.yourssu.roomescape.reservation;
 
+import com.yourssu.roomescape.member.LoginMember;
 import com.yourssu.roomescape.theme.Theme;
 import com.yourssu.roomescape.time.Time;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -43,12 +44,12 @@ public class ReservationDao {
                         )));
     }
 
-    public Reservation save(ReservationRequest reservationRequest) {
+    public Reservation save(ReservationRequest reservationRequest, LoginMember member) {
         KeyHolder keyHolder = new GeneratedKeyHolder();
         jdbcTemplate.update(connection -> {
             PreparedStatement ps = connection.prepareStatement("INSERT INTO reservation(date, name, theme_id, time_id) VALUES (?, ?, ?, ?)", new String[]{"id"});
             ps.setString(1, reservationRequest.getDate());
-            ps.setString(2, reservationRequest.getName());
+            ps.setString(2, member.getName());
             ps.setLong(3, reservationRequest.getTheme());
             ps.setLong(4, reservationRequest.getTime());
             return ps;
@@ -64,7 +65,7 @@ public class ReservationDao {
 
         return new Reservation(
                 keyHolder.getKey().longValue(),
-                reservationRequest.getName(),
+                member.getName(),
                 reservationRequest.getDate(),
                 time,
                 theme

--- a/src/main/java/com/yourssu/roomescape/reservation/ReservationDao.java
+++ b/src/main/java/com/yourssu/roomescape/reservation/ReservationDao.java
@@ -1,6 +1,5 @@
 package com.yourssu.roomescape.reservation;
 
-import com.yourssu.roomescape.member.LoginMember;
 import com.yourssu.roomescape.theme.Theme;
 import com.yourssu.roomescape.time.Time;
 import org.springframework.jdbc.core.JdbcTemplate;

--- a/src/main/java/com/yourssu/roomescape/reservation/ReservationDao.java
+++ b/src/main/java/com/yourssu/roomescape/reservation/ReservationDao.java
@@ -44,12 +44,12 @@ public class ReservationDao {
                         )));
     }
 
-    public Reservation save(ReservationRequest reservationRequest, LoginMember member) {
+    public Reservation save(ReservationRequest reservationRequest, String name) {
         KeyHolder keyHolder = new GeneratedKeyHolder();
         jdbcTemplate.update(connection -> {
             PreparedStatement ps = connection.prepareStatement("INSERT INTO reservation(date, name, theme_id, time_id) VALUES (?, ?, ?, ?)", new String[]{"id"});
             ps.setString(1, reservationRequest.getDate());
-            ps.setString(2, member.getName());
+            ps.setString(2, name);
             ps.setLong(3, reservationRequest.getTheme());
             ps.setLong(4, reservationRequest.getTime());
             return ps;
@@ -65,7 +65,7 @@ public class ReservationDao {
 
         return new Reservation(
                 keyHolder.getKey().longValue(),
-                member.getName(),
+                name,
                 reservationRequest.getDate(),
                 time,
                 theme

--- a/src/main/java/com/yourssu/roomescape/reservation/ReservationRequest.java
+++ b/src/main/java/com/yourssu/roomescape/reservation/ReservationRequest.java
@@ -4,6 +4,7 @@ public class ReservationRequest {
     private String date;
     private Long theme;
     private Long time;
+    private String name;
 
     public String getDate() {
         return date;
@@ -16,4 +17,5 @@ public class ReservationRequest {
     public Long getTime() {
         return time;
     }
+    public String getName(){return name;}
 }

--- a/src/main/java/com/yourssu/roomescape/reservation/ReservationRequest.java
+++ b/src/main/java/com/yourssu/roomescape/reservation/ReservationRequest.java
@@ -1,14 +1,9 @@
 package com.yourssu.roomescape.reservation;
 
 public class ReservationRequest {
-    private String name;
     private String date;
     private Long theme;
     private Long time;
-
-    public String getName() {
-        return name;
-    }
 
     public String getDate() {
         return date;

--- a/src/main/java/com/yourssu/roomescape/reservation/ReservationRequest.java
+++ b/src/main/java/com/yourssu/roomescape/reservation/ReservationRequest.java
@@ -17,5 +17,8 @@ public class ReservationRequest {
     public Long getTime() {
         return time;
     }
-    public String getName(){return name;}
+
+    public String getName() {
+        return name;
+    }
 }

--- a/src/main/java/com/yourssu/roomescape/reservation/ReservationService.java
+++ b/src/main/java/com/yourssu/roomescape/reservation/ReservationService.java
@@ -1,6 +1,8 @@
 package com.yourssu.roomescape.reservation;
 
 import com.yourssu.roomescape.member.LoginMember;
+import com.yourssu.roomescape.member.Member;
+import com.yourssu.roomescape.member.MemberDao;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -8,15 +10,24 @@ import java.util.List;
 @Service
 public class ReservationService {
     private ReservationDao reservationDao;
+    private MemberDao memberDao;
 
-    public ReservationService(ReservationDao reservationDao) {
+    public ReservationService(ReservationDao reservationDao, MemberDao memberDao) {
         this.reservationDao = reservationDao;
+        this.memberDao = memberDao;
     }
 
-    public ReservationResponse save(ReservationRequest reservationRequest, LoginMember member) {
-        Reservation reservation = reservationDao.save(reservationRequest, member);
+    public ReservationResponse save(ReservationRequest reservationRequest, LoginMember loginMember) {
+        if (reservationRequest.getName() == null) {
+            Reservation reservation = reservationDao.save(reservationRequest, loginMember.getName());
 
-        return new ReservationResponse(reservation.getId(), member.getName(), reservation.getTheme().getName(), reservation.getDate(), reservation.getTime().getValue());
+            return new ReservationResponse(reservation.getId(), loginMember.getName(), reservation.getTheme().getName(), reservation.getDate(), reservation.getTime().getValue());
+        } else {
+            Member member = memberDao.findByName(reservationRequest.getName());
+            Reservation reservation = reservationDao.save(reservationRequest, member.getName());
+
+            return new ReservationResponse(reservation.getId(), reservationRequest.getName(), reservation.getTheme().getName(), reservation.getDate(), reservation.getTime().getValue());
+        }
     }
 
     public void deleteById(Long id) {

--- a/src/main/java/com/yourssu/roomescape/reservation/ReservationService.java
+++ b/src/main/java/com/yourssu/roomescape/reservation/ReservationService.java
@@ -1,5 +1,6 @@
 package com.yourssu.roomescape.reservation;
 
+import com.yourssu.roomescape.member.LoginMember;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -12,10 +13,10 @@ public class ReservationService {
         this.reservationDao = reservationDao;
     }
 
-    public ReservationResponse save(ReservationRequest reservationRequest) {
-        Reservation reservation = reservationDao.save(reservationRequest);
+    public ReservationResponse save(ReservationRequest reservationRequest, LoginMember member) {
+        Reservation reservation = reservationDao.save(reservationRequest, member);
 
-        return new ReservationResponse(reservation.getId(), reservationRequest.getName(), reservation.getTheme().getName(), reservation.getDate(), reservation.getTime().getValue());
+        return new ReservationResponse(reservation.getId(), member.getName(), reservation.getTheme().getName(), reservation.getDate(), reservation.getTime().getValue());
     }
 
     public void deleteById(Long id) {

--- a/src/main/java/com/yourssu/roomescape/utils/TokenUtil.java
+++ b/src/main/java/com/yourssu/roomescape/utils/TokenUtil.java
@@ -1,5 +1,8 @@
 package com.yourssu.roomescape.utils;
 
+import com.yourssu.roomescape.member.Member;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
 import jakarta.servlet.http.Cookie;
 
 public class TokenUtil {
@@ -13,5 +16,24 @@ public class TokenUtil {
             }
         }
         return null;
+    }
+
+    public String createToken(Member member){
+        String secretKey = "Yn2kjibddFAWtnPJ2AFlL8WXmohJMCvigQggaEypa5E=";
+
+        return Jwts.builder()
+                .setSubject(member.getId().toString())
+                .claim("name", member.getName())
+                .claim("role", member.getRole())
+                .signWith(Keys.hmacShaKeyFor(secretKey.getBytes()))
+                .compact();
+    }
+
+    public Long parseTokenToId(String token){
+        return Long.valueOf(Jwts.parser()
+                .verifyWith(Keys.hmacShaKeyFor("Yn2kjibddFAWtnPJ2AFlL8WXmohJMCvigQggaEypa5E=".getBytes()))
+                .build()
+                .parseSignedClaims(token)
+                .getBody().getSubject());
     }
 }

--- a/src/main/java/com/yourssu/roomescape/utils/TokenUtil.java
+++ b/src/main/java/com/yourssu/roomescape/utils/TokenUtil.java
@@ -17,24 +17,25 @@ public class TokenUtil {
     }
 
     public String extractTokenFromCookie(Cookie[] cookies){
-        if (cookies != null) {
-            for (Cookie cookie : cookies) {
-                if (cookie.getName().equals("token")) {
-                    return cookie.getValue();
-                }
+        if (cookies == null || cookies.length == 0) {
+            return null;
+        }
+        for (Cookie cookie : cookies) {
+            if (cookie != null && "token".equals(cookie.getName())) {
+                return cookie.getValue();
             }
         }
+
         return null;
     }
 
     public String createToken(Member member){
-        String secretKey = tokenProperty.getSecretKey();
 
         return Jwts.builder()
                 .setSubject(member.getId().toString())
                 .claim("name", member.getName())
                 .claim("role", member.getRole())
-                .signWith(Keys.hmacShaKeyFor(secretKey.getBytes()))
+                .signWith(Keys.hmacShaKeyFor(tokenProperty.getSecretKey().getBytes()))
                 .compact();
     }
 

--- a/src/main/java/com/yourssu/roomescape/utils/TokenUtil.java
+++ b/src/main/java/com/yourssu/roomescape/utils/TokenUtil.java
@@ -4,6 +4,7 @@ import com.yourssu.roomescape.member.Member;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import jakarta.servlet.http.Cookie;
+import org.springframework.stereotype.Component;
 
 public class TokenUtil {
 

--- a/src/main/java/com/yourssu/roomescape/utils/TokenUtil.java
+++ b/src/main/java/com/yourssu/roomescape/utils/TokenUtil.java
@@ -1,0 +1,17 @@
+package com.yourssu.roomescape.utils;
+
+import jakarta.servlet.http.Cookie;
+
+public class TokenUtil {
+
+    public String extractTokenFromCookie(Cookie[] cookies){
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (cookie.getName().equals("token")) {
+                    return cookie.getValue();
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/yourssu/roomescape/utils/TokenUtil.java
+++ b/src/main/java/com/yourssu/roomescape/utils/TokenUtil.java
@@ -1,12 +1,20 @@
 package com.yourssu.roomescape.utils;
 
 import com.yourssu.roomescape.member.Member;
+import com.yourssu.roomescape.property.TokenProperty;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import jakarta.servlet.http.Cookie;
 import org.springframework.stereotype.Component;
 
+@Component
 public class TokenUtil {
+
+    private final TokenProperty tokenProperty;
+
+    public TokenUtil(TokenProperty tokenProperty) {
+        this.tokenProperty = tokenProperty;
+    }
 
     public String extractTokenFromCookie(Cookie[] cookies){
         if (cookies != null) {
@@ -20,7 +28,7 @@ public class TokenUtil {
     }
 
     public String createToken(Member member){
-        String secretKey = "Yn2kjibddFAWtnPJ2AFlL8WXmohJMCvigQggaEypa5E=";
+        String secretKey = tokenProperty.getSecretKey();
 
         return Jwts.builder()
                 .setSubject(member.getId().toString())
@@ -32,7 +40,7 @@ public class TokenUtil {
 
     public Long parseTokenToId(String token){
         return Long.valueOf(Jwts.parser()
-                .verifyWith(Keys.hmacShaKeyFor("Yn2kjibddFAWtnPJ2AFlL8WXmohJMCvigQggaEypa5E=".getBytes()))
+                .verifyWith(Keys.hmacShaKeyFor(tokenProperty.getSecretKey().getBytes()))
                 .build()
                 .parseSignedClaims(token)
                 .getBody().getSubject());

--- a/src/main/java/com/yourssu/roomescape/validator/MemberValidator.java
+++ b/src/main/java/com/yourssu/roomescape/validator/MemberValidator.java
@@ -1,0 +1,14 @@
+package com.yourssu.roomescape.validator;
+
+import com.yourssu.roomescape.member.Member;
+
+import static com.yourssu.roomescape.exception.ExceptionMessage.NO_EXIST_MEMBER;
+
+public class MemberValidator {
+
+    public static void validateMemeber(Member member){
+        if (member == null){
+            throw new IllegalArgumentException(NO_EXIST_MEMBER.getMessage());
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,4 +8,4 @@ spring.datasource.url=jdbc:h2:mem:database
 #spring.jpa.ddl-auto=create-drop
 #spring.jpa.defer-datasource-initialization=true
 
-#roomescape.auth.jwt.secret= Yn2kjibddFAWtnPJ2AFlL8WXmohJMCvigQggaEypa5E=
+roomescape.auth.jwt.secret= Yn2kjibddFAWtnPJ2AFlL8WXmohJMCvigQggaEypa5E=

--- a/src/test/java/com/yourssu/roomescape/MissionStepTest.java
+++ b/src/test/java/com/yourssu/roomescape/MissionStepTest.java
@@ -1,9 +1,6 @@
 package com.yourssu.roomescape;
 
 import com.yourssu.roomescape.reservation.ReservationResponse;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
-import io.jsonwebtoken.security.Keys;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.response.ExtractableResponse;

--- a/src/test/java/com/yourssu/roomescape/MissionStepTest.java
+++ b/src/test/java/com/yourssu/roomescape/MissionStepTest.java
@@ -1,5 +1,9 @@
 package com.yourssu.roomescape;
 
+import com.yourssu.roomescape.reservation.ReservationResponse;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.response.ExtractableResponse;
@@ -35,4 +39,5 @@ public class MissionStepTest {
 
         assertThat(token).isNotBlank();
     }
+
 }


### PR DESCRIPTION
# ✒️ 과제

## 🔑 과제 내용

1. TODO
- [x] 1단계 - 로그인
- [x] 2단계 - 로그인 리팩토링
- [x] 3단계 - 관리자 기능
<img width="1282" alt="image" src="https://github.com/user-attachments/assets/3b271552-ba6e-4716-8c51-4bf4ecb99768" />


## 🧐 고민한 내용 + 공부한 내용
우선 과제를 하면서 쿠키와 토큰 그리고 HandlerMethodArgumentResolver, HandlerInterceptor에 대해서 새롭게 알게되었습니다.. 어렵네요...
- 1단계 구현
1단계를 구현하면서 많은 걸 배웠는데, 그중에서도 쿠키에 대해 새롭게 이해하게 되었습니다. **쿠키는 서버에서 클라이언트(브라우저)로 전달되어 저장되는 작은 데이터 조각입니다.** 로그인에 성공하면 서버는 JWT 토큰을 쿠키에 담아 응답하고, 이 쿠키는 브라우저에 저장됩니다.
이후 클라이언트가 서버에 요청을 보낼 때마다 브라우저가 자동으로 쿠키를 함께 전송해주기 때문에, 사용자는 매번 로그인할 필요 없이 인증 상태를 유지할 수 있습니다. 서버는 요청에 포함된 쿠키에서 토큰을 꺼내 검증한 뒤, 유효한 토큰이라면 해당 사용자가 로그인된 상태임을 판단합니다. 
우선 1단계에서 원하는 것이 /login을 만드는 것이었기 때문에 이메일과 패스워드를 받아 로그인을 하면 jwt토큰을 쿠키에 저장하는 api를 만들었습니다. 이때 중요한건 HttpServletResponse도 함께 받아야합니다! HttpServletResponse는 스프링이 자동으로 넣어주는 서버 응답 객체로 쿠키를 만들고 응답에 추가할 때 사용합니다. `response.addCookie()`를 통해 브라우저에 쿠키를 저장합니다
예시를 보면 응답에 `Set-Cookie: token=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwibmFtZSI6ImFkbWluIiwicm9sZSI6IkFETUlOIn0.cwnHsltFeEtOzMHs2Q5-ItawgvBZ140OyWecppNlLoI; Path=/; HttpOnly` 형태로 되어있는데 이는 서버가 token이라는 쿠키를 주는 것입니다. Set-Cookie는 서버가 쿠키를 설정할 때 사용하는 HTTP 응답 헤더입니다.
저는 TokenUtil이라는 클래스를 만들어서 토큰과 관련된 메서드들을 정리했는데 이렇게 한 이유는 중복된 부분도 많고 한 곳에서 관리하면 가독성과 책임분리가 더 잘 될것이라고 생각했기 때문입니다. 
jwt토큰을 만들때 주어진 예시를 따라 멤버의 ID를 subject로 하고 추가 정보로 role과 name을 함께 주었습니다.
.
/check/login api 는 Cookie에서 토큰 정보를 추출해야하기 때문에 TokenUtil에 extractTokenFromCookie 메서드를 만들어서 브라우저가 가지고 있는 쿠키로부터 토큰을 추출해내도록 했습니다. 이때 HttpServletRequest는 브라우저가 서버로 보낸 요청 정보를 담고 있는 객체로 쿠키에 대한 정보를 가지고 있습니다.` request.getCookies();`로 쿠키를 꺼낼 수 있습니다. 쿠키에서 추출한 토큰을 통해 멤버 객체를 찾고 이를 반환합니다.
.
1단계를 구현하며 정리되지 않았던 내용들이 PR을 작성하며 점점 정리가 되고 있어서 좋네요..ㅎ 중요한 쿠키 그리고 토큰에 대해서 배울 수 있었던 단계였습니다
- 2단계 구현
HandlerMethodArgumentResolver라는 인터페이스를 이용해 구현하는 단계였습니다. HandlerMethodArgumentResolver는 처음 들어봐서 컨트롤러의 파라미터 값을 자동으로 주입해주는 인터페이스입니다. 로그인에서는 JWT 토큰에서 로그인 정보를 꺼내서 컨트롤러 파라미터에 자동으로 넣을 수 있습니다.
인터페이스에 있는 두가지 메소드를 오버라이딩 해야하는데 하나는 supportsParameter로 파라미터로 지정한 클래스가 왔을때 resolveArgument() 호출해서 객체에 값을 자동으로 넣어줍니다. 따라서 제가 작성한 resolveArgument()에서는 브라우저로부터 받은 쿠키에서 토큰을 추출해 멤버를 반환합니다.
‼️ 트러블 슈팅 
1. 저는 해당 클래스만 작성하면 된다고 생각하고 실행을 했는데 적용이 안되는 문제가 발생했습니다. 알고보니 LoginMemberArgumentResolver를 스프링에 등록하는 과정이 필요하다고 합니다.. 스프링의 웹 설정을 커스터마이징하기 위한 클래스인 WebMvcConfigurer인터페이스를 구현하는 클래스를 만들어서 `addArgumentResolvers`를 해줍니다! 이래야 잘 등록이 되어 작동합니다!
2. 아래의 조건을 보지 않고 구현해서 테스트케이스가 계속 실패했습니다.. 이 후 깨닫고 케이스를 나눠 name값을 각각 다르게 설정했습니다.
<img width="702" alt="image" src="https://github.com/user-attachments/assets/8e23c81b-aecf-48e2-b616-27b07621224b" />

- 3단계 구현
HandlerInterceptor라는 인터페이스를 이용해 구현하는 단계였습니다. 이를 통해 컨트롤러 진입 전에 쿠키에서 role을 확인하고, 어드민인 경우만 어드민 페이지가 허락되도록 하는 것이 조건입니다. HandlerInterceptor는 컨트롤러 실행 전, 실행 후, 뷰 렌더링 후에 요청을 가로채서 처리할 수 있게 해주는 인터셉터 인터페이스입니다. 이중 컨트롤러 이전에 가로채야하므로 `preHandle`을 구현했습니다.  이것도 마찬가지로 `addInterceptors`를 통해 등록이 필요합니다!


## ❓궁금한 내용
- LoginMemberArgumentResolver에서 주어진 코드에 `private MemberService memberService;` 를 의존성 주입받아서 `MemberResponse member = memberService.checkLogin(token);`을 통해 멤버 객체를 얻는게 왜 MemberDao를 의존성 주입받아서 `MemberDao member = memberDao.findById(tokenUtil.parseTokenToId(token));`을 하는 것보다 나은지 궁금합니다!