### PR TITLE
[Logan] Spring MVC 1~3단계 미션

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,6 @@ dependencies {
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test:3.4.4'
     testImplementation 'io.rest-assured:rest-assured:5.5.1'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.12.1'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/yourssu/roomescape/auth/AdminAuthorizationInterceptor.java
+++ b/src/main/java/com/yourssu/roomescape/auth/AdminAuthorizationInterceptor.java
@@ -1,0 +1,34 @@
+package com.yourssu.roomescape.auth;
+
+import com.yourssu.roomescape.jwt.TokenExtractor;
+import com.yourssu.roomescape.member.Member;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Component
+public class AdminAuthorizationInterceptor implements HandlerInterceptor {
+
+    private final AuthService authService;
+
+    public AdminAuthorizationInterceptor(AuthService authService) {
+        this.authService = authService;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        Cookie[] cookies = request.getCookies();
+        String token = TokenExtractor.extractTokenFromCookies(cookies);
+        Member member = authService.checkLogin(token);
+
+        if(!"ADMIN".equals(member.getRole())) {
+            response.setStatus(401);
+            response.getWriter().write("해당 접근에 대한 권한이 없습니다.");
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/com/yourssu/roomescape/auth/AuthController.java
+++ b/src/main/java/com/yourssu/roomescape/auth/AuthController.java
@@ -1,7 +1,6 @@
 package com.yourssu.roomescape.auth;
 
-import com.yourssu.roomescape.exception.CustomException;
-import com.yourssu.roomescape.exception.ErrorCode;
+import com.yourssu.roomescape.jwt.TokenExtractor;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -10,8 +9,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.Arrays;
 
 @RestController
 public class AuthController {
@@ -37,15 +34,7 @@ public class AuthController {
     @GetMapping("/login/check")
     public ResponseEntity<CheckLoginResponse> loginCheck(HttpServletRequest request) {
         Cookie[] cookies = request.getCookies();
-        String token = null;
-
-        if (cookies != null) {
-            token = Arrays.stream(cookies)
-                    .filter(cookie -> "token".equals(cookie.getName()))
-                    .map(Cookie::getValue)
-                    .findFirst()
-                    .orElseThrow(() -> new CustomException(ErrorCode.TOKEN_NOT_FOUND));
-        }
+        String token = TokenExtractor.extractTokenFromCookies(cookies);
 
         String name = authService.checkLogin(token).getName();
         return ResponseEntity.ok().body(new CheckLoginResponse(name));

--- a/src/main/java/com/yourssu/roomescape/auth/AuthController.java
+++ b/src/main/java/com/yourssu/roomescape/auth/AuthController.java
@@ -47,8 +47,7 @@ public class AuthController {
                     .orElseThrow(() -> new CustomException(ErrorCode.TOKEN_NOT_FOUND));
         }
 
-        CheckLoginResponse checkLoginResponse = authService.checkLogin(token);
-
-        return ResponseEntity.ok().body(checkLoginResponse);
+        String name = authService.checkLogin(token).getName();
+        return ResponseEntity.ok().body(new CheckLoginResponse(name));
     }
 }

--- a/src/main/java/com/yourssu/roomescape/auth/AuthController.java
+++ b/src/main/java/com/yourssu/roomescape/auth/AuthController.java
@@ -1,0 +1,54 @@
+package com.yourssu.roomescape.auth;
+
+import com.yourssu.roomescape.exception.CustomException;
+import com.yourssu.roomescape.exception.ErrorCode;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Arrays;
+
+@RestController
+public class AuthController {
+
+    private final AuthService authService;
+
+    public AuthController(AuthService authService) {
+        this.authService = authService;
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<?> login(@RequestBody LoginRequest loginRequest, HttpServletResponse response) {
+
+        String accessToken = authService.login(loginRequest);
+        Cookie cookie = new Cookie("token", accessToken);
+        cookie.setHttpOnly(true);
+        cookie.setPath("/");
+        cookie.setMaxAge(0);
+        response.addCookie(cookie);
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/login/check")
+    public ResponseEntity<CheckLoginResponse> loginCheck(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        String token = null;
+
+        if (cookies != null) {
+            token = Arrays.stream(cookies)
+                    .filter(cookie -> "token".equals(cookie.getName()))
+                    .map(Cookie::getValue)
+                    .findFirst()
+                    .orElseThrow(() -> new CustomException(ErrorCode.TOKEN_NOT_FOUND));
+        }
+
+        CheckLoginResponse checkLoginResponse = authService.checkLogin(token);
+
+        return ResponseEntity.ok().body(checkLoginResponse);
+    }
+}

--- a/src/main/java/com/yourssu/roomescape/auth/AuthService.java
+++ b/src/main/java/com/yourssu/roomescape/auth/AuthService.java
@@ -1,0 +1,29 @@
+package com.yourssu.roomescape.auth;
+
+import com.yourssu.roomescape.jwt.TokenProvider;
+import com.yourssu.roomescape.member.Member;
+import com.yourssu.roomescape.member.MemberDao;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AuthService {
+
+    private final MemberDao memberDao;
+    private final TokenProvider tokenProvider;
+
+    public AuthService(TokenProvider tokenProvider, MemberDao memberDao) {
+        this.tokenProvider = tokenProvider;
+        this.memberDao = memberDao;
+    }
+
+    public String login(LoginRequest loginRequest) {
+        Member member = memberDao.findByEmailAndPassword(loginRequest.getEmail(), loginRequest.getPassword());
+        return tokenProvider.createToken(member.getEmail());
+    }
+
+    public CheckLoginResponse checkLogin(String token) {
+        String payload = tokenProvider.getPayload(token);
+        Member member = memberDao.findByEmail(payload);
+        return new CheckLoginResponse(member.getName());
+    }
+}

--- a/src/main/java/com/yourssu/roomescape/auth/AuthService.java
+++ b/src/main/java/com/yourssu/roomescape/auth/AuthService.java
@@ -21,9 +21,8 @@ public class AuthService {
         return tokenProvider.createToken(member.getEmail());
     }
 
-    public CheckLoginResponse checkLogin(String token) {
+    public Member checkLogin(String token) {
         String payload = tokenProvider.getPayload(token);
-        Member member = memberDao.findByEmail(payload);
-        return new CheckLoginResponse(member.getName());
+        return memberDao.findByEmail(payload);
     }
 }

--- a/src/main/java/com/yourssu/roomescape/auth/CheckLoginResponse.java
+++ b/src/main/java/com/yourssu/roomescape/auth/CheckLoginResponse.java
@@ -1,0 +1,14 @@
+package com.yourssu.roomescape.auth;
+
+public class CheckLoginResponse {
+
+    private String name;
+
+    public CheckLoginResponse(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/src/main/java/com/yourssu/roomescape/auth/LoginMember.java
+++ b/src/main/java/com/yourssu/roomescape/auth/LoginMember.java
@@ -1,0 +1,11 @@
+package com.yourssu.roomescape.auth;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LoginMember {
+}

--- a/src/main/java/com/yourssu/roomescape/auth/LoginMemberArgumentResolver.java
+++ b/src/main/java/com/yourssu/roomescape/auth/LoginMemberArgumentResolver.java
@@ -1,7 +1,6 @@
 package com.yourssu.roomescape.auth;
 
-import com.yourssu.roomescape.exception.CustomException;
-import com.yourssu.roomescape.exception.ErrorCode;
+import com.yourssu.roomescape.jwt.TokenExtractor;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.core.MethodParameter;
@@ -10,8 +9,6 @@ import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
-
-import java.util.Arrays;
 
 @Component
 public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolver {
@@ -32,15 +29,7 @@ public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolve
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
 
         Cookie[] cookies = request.getCookies();
-        String token = null;
-
-        if (cookies != null) {
-            token = Arrays.stream(cookies)
-                    .filter(cookie -> "token".equals(cookie.getName()))
-                    .map(Cookie::getValue)
-                    .findFirst()
-                    .orElseThrow(() -> new CustomException(ErrorCode.TOKEN_NOT_FOUND));
-        }
+        String token = TokenExtractor.extractTokenFromCookies(cookies);
 
         return authService.checkLogin(token);
     }

--- a/src/main/java/com/yourssu/roomescape/auth/LoginMemberArgumentResolver.java
+++ b/src/main/java/com/yourssu/roomescape/auth/LoginMemberArgumentResolver.java
@@ -1,6 +1,7 @@
 package com.yourssu.roomescape.auth;
 
 import com.yourssu.roomescape.jwt.TokenExtractor;
+import com.yourssu.roomescape.member.Member;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.core.MethodParameter;
@@ -25,7 +26,7 @@ public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolve
     }
 
     @Override
-    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+    public Member resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
         HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
 
         Cookie[] cookies = request.getCookies();

--- a/src/main/java/com/yourssu/roomescape/auth/LoginMemberArgumentResolver.java
+++ b/src/main/java/com/yourssu/roomescape/auth/LoginMemberArgumentResolver.java
@@ -1,0 +1,47 @@
+package com.yourssu.roomescape.auth;
+
+import com.yourssu.roomescape.exception.CustomException;
+import com.yourssu.roomescape.exception.ErrorCode;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import java.util.Arrays;
+
+@Component
+public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final AuthService authService;
+
+    public LoginMemberArgumentResolver(AuthService authService) {
+        this.authService = authService;
+    }
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(LoginMember.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        HttpServletRequest request = (HttpServletRequest) webRequest.getNativeRequest();
+
+        Cookie[] cookies = request.getCookies();
+        String token = null;
+
+        if (cookies != null) {
+            token = Arrays.stream(cookies)
+                    .filter(cookie -> "token".equals(cookie.getName()))
+                    .map(Cookie::getValue)
+                    .findFirst()
+                    .orElseThrow(() -> new CustomException(ErrorCode.TOKEN_NOT_FOUND));
+        }
+
+        return authService.checkLogin(token);
+    }
+}

--- a/src/main/java/com/yourssu/roomescape/auth/LoginRequest.java
+++ b/src/main/java/com/yourssu/roomescape/auth/LoginRequest.java
@@ -1,0 +1,19 @@
+package com.yourssu.roomescape.auth;
+
+public class LoginRequest {
+    private String email;
+    private String password;
+
+    public LoginRequest(String email, String password) {
+        this.email = email;
+        this.password = password;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+}

--- a/src/main/java/com/yourssu/roomescape/config/WebConfig.java
+++ b/src/main/java/com/yourssu/roomescape/config/WebConfig.java
@@ -1,8 +1,10 @@
 package com.yourssu.roomescape.config;
 
+import com.yourssu.roomescape.auth.AdminAuthorizationInterceptor;
 import com.yourssu.roomescape.auth.LoginMemberArgumentResolver;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import java.util.List;
@@ -11,13 +13,21 @@ import java.util.List;
 public class WebConfig implements WebMvcConfigurer {
 
     private final LoginMemberArgumentResolver loginMemberArgumentResolver;
+    private final AdminAuthorizationInterceptor adminAuthorizationInterceptor;
 
-    public WebConfig(LoginMemberArgumentResolver loginMemberArgumentResolver) {
+    public WebConfig(LoginMemberArgumentResolver loginMemberArgumentResolver, AdminAuthorizationInterceptor adminAuthorizationInterceptor) {
         this.loginMemberArgumentResolver = loginMemberArgumentResolver;
+        this.adminAuthorizationInterceptor = adminAuthorizationInterceptor;
     }
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(loginMemberArgumentResolver);
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(adminAuthorizationInterceptor)
+                .addPathPatterns("/admin/**");
     }
 }

--- a/src/main/java/com/yourssu/roomescape/config/WebConfig.java
+++ b/src/main/java/com/yourssu/roomescape/config/WebConfig.java
@@ -1,0 +1,23 @@
+package com.yourssu.roomescape.config;
+
+import com.yourssu.roomescape.auth.LoginMemberArgumentResolver;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    private final LoginMemberArgumentResolver loginMemberArgumentResolver;
+
+    public WebConfig(LoginMemberArgumentResolver loginMemberArgumentResolver) {
+        this.loginMemberArgumentResolver = loginMemberArgumentResolver;
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(loginMemberArgumentResolver);
+    }
+}

--- a/src/main/java/com/yourssu/roomescape/exception/CustomException.java
+++ b/src/main/java/com/yourssu/roomescape/exception/CustomException.java
@@ -1,0 +1,15 @@
+package com.yourssu.roomescape.exception;
+
+public class CustomException extends RuntimeException {
+
+	private final ErrorCode errorCode;
+
+	public ErrorCode getErrorCode() {
+		return errorCode;
+	}
+
+	public CustomException(ErrorCode errorCode) {
+		super(errorCode.getMessage());
+		this.errorCode = errorCode;
+	}
+}

--- a/src/main/java/com/yourssu/roomescape/exception/ErrorCode.java
+++ b/src/main/java/com/yourssu/roomescape/exception/ErrorCode.java
@@ -5,7 +5,8 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
 	TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "쿠키에 토큰이 존재하지 않습니다."),
-	MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자의 정보를 찾을 수 없습니다.");
+	MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자의 정보를 찾을 수 없습니다."),
+	INVALID_RESERVATION_REQUEST(HttpStatus.BAD_REQUEST, "예약 요청 값이 누락되었습니다.");
 
 	private final HttpStatus status;
 	private final String message;

--- a/src/main/java/com/yourssu/roomescape/exception/ErrorCode.java
+++ b/src/main/java/com/yourssu/roomescape/exception/ErrorCode.java
@@ -4,9 +4,11 @@ import org.springframework.http.HttpStatus;
 
 public enum ErrorCode {
 
+	COOKIE_NOT_FOUND(HttpStatus.UNAUTHORIZED, "쿠키가 존재하지 않습니다."),
 	TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "쿠키에 토큰이 존재하지 않습니다."),
 	MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자의 정보를 찾을 수 없습니다."),
-	INVALID_RESERVATION_REQUEST(HttpStatus.BAD_REQUEST, "예약 요청 값이 누락되었습니다.");
+	INVALID_RESERVATION_REQUEST(HttpStatus.BAD_REQUEST, "예약 요청 값이 누락되었습니다."),
+	UNAUTHORIZED_ACCESS(HttpStatus.UNAUTHORIZED, "해당 접근에 대한 권한이 없습니다.");
 
 	private final HttpStatus status;
 	private final String message;

--- a/src/main/java/com/yourssu/roomescape/exception/ErrorCode.java
+++ b/src/main/java/com/yourssu/roomescape/exception/ErrorCode.java
@@ -1,0 +1,25 @@
+package com.yourssu.roomescape.exception;
+
+import org.springframework.http.HttpStatus;
+
+public enum ErrorCode {
+
+	TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "쿠키에 토큰이 존재하지 않습니다."),
+	MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자의 정보를 찾을 수 없습니다.");
+
+	private final HttpStatus status;
+	private final String message;
+
+	ErrorCode(HttpStatus status, String message) {
+		this.status = status;
+		this.message = message;
+	}
+
+	public HttpStatus getStatus() {
+		return status;
+	}
+
+	public String getMessage() {
+		return message;
+	}
+}

--- a/src/main/java/com/yourssu/roomescape/exception/ErrorResponse.java
+++ b/src/main/java/com/yourssu/roomescape/exception/ErrorResponse.java
@@ -1,0 +1,20 @@
+package com.yourssu.roomescape.exception;
+
+public class ErrorResponse {
+
+    private final String code;
+    private final String message;
+
+    public ErrorResponse(String code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/yourssu/roomescape/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/yourssu/roomescape/exception/GlobalExceptionHandler.java
@@ -1,0 +1,16 @@
+package com.yourssu.roomescape.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        ErrorResponse response = new ErrorResponse(errorCode.name(), errorCode.getMessage());
+        return ResponseEntity.status(errorCode.getStatus()).body(response);
+    }
+}

--- a/src/main/java/com/yourssu/roomescape/jwt/TokenExtractor.java
+++ b/src/main/java/com/yourssu/roomescape/jwt/TokenExtractor.java
@@ -1,0 +1,26 @@
+package com.yourssu.roomescape.jwt;
+
+import com.yourssu.roomescape.exception.CustomException;
+import com.yourssu.roomescape.exception.ErrorCode;
+import jakarta.servlet.http.Cookie;
+
+import java.util.Arrays;
+
+public class TokenExtractor {
+
+    private TokenExtractor() {
+        // 객체 생성 방지
+    }
+
+    public static String extractTokenFromCookies(Cookie[] cookies) {
+        if (cookies == null) {
+            throw new CustomException(ErrorCode.COOKIE_NOT_FOUND);
+        }
+
+        return Arrays.stream(cookies)
+                .filter(cookie -> "token".equals(cookie.getName()))
+                .map(Cookie::getValue)
+                .findFirst()
+                .orElseThrow(() -> new CustomException(ErrorCode.TOKEN_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/yourssu/roomescape/jwt/TokenProvider.java
+++ b/src/main/java/com/yourssu/roomescape/jwt/TokenProvider.java
@@ -1,0 +1,39 @@
+package com.yourssu.roomescape.jwt;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+
+@Component
+public class TokenProvider {
+    @Value("${security.jwt.token.secret-key}")
+    private String secretKey;
+    @Value("${security.jwt.token.expire-length}")
+    private long validityInMilliseconds;
+
+    public String createToken(String payload) {
+        Claims claims = Jwts.claims().subject(payload).build();
+        Date now = new Date();
+        Date validity = new Date(now.getTime() + validityInMilliseconds);
+
+
+        return Jwts.builder()
+                .claims(claims)
+                .issuedAt(now)
+                .expiration(validity)
+                .signWith(Keys.hmacShaKeyFor(secretKey.getBytes()))
+                .compact();
+    }
+
+    public String getPayload(String token) {
+        return Jwts.parser()
+                .verifyWith(Keys.hmacShaKeyFor(secretKey.getBytes()))
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .getSubject();
+    }
+}

--- a/src/main/java/com/yourssu/roomescape/member/MemberDao.java
+++ b/src/main/java/com/yourssu/roomescape/member/MemberDao.java
@@ -63,4 +63,21 @@ public class MemberDao {
             throw new CustomException(ErrorCode.MEMBER_NOT_FOUND);
         }
     }
+
+    public Member findByName(String name) {
+        try {
+            return jdbcTemplate.queryForObject(
+                    "SELECT id, name, email, role FROM member WHERE name = ?",
+                    (rs, rowNum) -> new Member(
+                            rs.getLong("id"),
+                            rs.getString("name"),
+                            rs.getString("email"),
+                            rs.getString("role")
+                    ),
+                    name
+            );
+        } catch (DataAccessException e) {
+            throw new CustomException(ErrorCode.MEMBER_NOT_FOUND);
+        }
+    }
 }

--- a/src/main/java/com/yourssu/roomescape/member/MemberDao.java
+++ b/src/main/java/com/yourssu/roomescape/member/MemberDao.java
@@ -1,5 +1,8 @@
 package com.yourssu.roomescape.member;
 
+import com.yourssu.roomescape.exception.CustomException;
+import com.yourssu.roomescape.exception.ErrorCode;
+import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.support.GeneratedKeyHolder;
 import org.springframework.jdbc.support.KeyHolder;
@@ -28,28 +31,36 @@ public class MemberDao {
     }
 
     public Member findByEmailAndPassword(String email, String password) {
-        return jdbcTemplate.queryForObject(
-                "SELECT id, name, email, role FROM member WHERE email = ? AND password = ?",
-                (rs, rowNum) -> new Member(
-                        rs.getLong("id"),
-                        rs.getString("name"),
-                        rs.getString("email"),
-                        rs.getString("role")
-                ),
-                email, password
-        );
+        try {
+            return jdbcTemplate.queryForObject(
+                    "SELECT id, name, email, role FROM member WHERE email = ? AND password = ?",
+                    (rs, rowNum) -> new Member(
+                            rs.getLong("id"),
+                            rs.getString("name"),
+                            rs.getString("email"),
+                            rs.getString("role")
+                    ),
+                    email, password
+            );
+        } catch (DataAccessException e) {
+            throw new CustomException(ErrorCode.MEMBER_NOT_FOUND);
+        }
     }
 
-    public Member findByName(String name) {
-        return jdbcTemplate.queryForObject(
-                "SELECT id, name, email, role FROM member WHERE name = ?",
-                (rs, rowNum) -> new Member(
-                        rs.getLong("id"),
-                        rs.getString("name"),
-                        rs.getString("email"),
-                        rs.getString("role")
-                ),
-                name
-        );
+    public Member findByEmail(String email) {
+        try {
+            return jdbcTemplate.queryForObject(
+                    "SELECT id, name, email, role FROM member WHERE email = ?",
+                    (rs, rowNum) -> new Member(
+                            rs.getLong("id"),
+                            rs.getString("name"),
+                            rs.getString("email"),
+                            rs.getString("role")
+                    ),
+                    email
+            );
+        } catch (DataAccessException e) {
+            throw new CustomException(ErrorCode.MEMBER_NOT_FOUND);
+        }
     }
 }

--- a/src/main/java/com/yourssu/roomescape/reservation/ReservationController.java
+++ b/src/main/java/com/yourssu/roomescape/reservation/ReservationController.java
@@ -1,5 +1,7 @@
 package com.yourssu.roomescape.reservation;
 
+import com.yourssu.roomescape.auth.LoginMember;
+import com.yourssu.roomescape.member.Member;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -21,14 +23,8 @@ public class ReservationController {
     }
 
     @PostMapping("/reservations")
-    public ResponseEntity create(@RequestBody ReservationRequest reservationRequest) {
-        if (reservationRequest.getName() == null
-                || reservationRequest.getDate() == null
-                || reservationRequest.getTheme() == null
-                || reservationRequest.getTime() == null) {
-            return ResponseEntity.badRequest().build();
-        }
-        ReservationResponse reservation = reservationService.save(reservationRequest);
+    public ResponseEntity<ReservationResponse> create(@RequestBody ReservationRequest reservationRequest, @LoginMember Member member) {
+        ReservationResponse reservation = reservationService.save(reservationRequest, member);
 
         return ResponseEntity.created(URI.create("/reservations/" + reservation.getId())).body(reservation);
     }

--- a/src/main/java/com/yourssu/roomescape/reservation/ReservationRequest.java
+++ b/src/main/java/com/yourssu/roomescape/reservation/ReservationRequest.java
@@ -2,9 +2,17 @@ package com.yourssu.roomescape.reservation;
 
 public class ReservationRequest {
     private String name;
+
     private String date;
     private Long theme;
     private Long time;
+
+    public ReservationRequest(String name, String date, Long theme, Long time) {
+        this.name = name;
+        this.date = date;
+        this.theme = theme;
+        this.time = time;
+    }
 
     public String getName() {
         return name;

--- a/src/main/java/com/yourssu/roomescape/reservation/ReservationService.java
+++ b/src/main/java/com/yourssu/roomescape/reservation/ReservationService.java
@@ -1,21 +1,51 @@
 package com.yourssu.roomescape.reservation;
 
+import com.yourssu.roomescape.exception.CustomException;
+import com.yourssu.roomescape.exception.ErrorCode;
+import com.yourssu.roomescape.member.Member;
+import com.yourssu.roomescape.member.MemberDao;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 public class ReservationService {
-    private ReservationDao reservationDao;
+    private final ReservationDao reservationDao;
+    private final MemberDao memberDao;
 
-    public ReservationService(ReservationDao reservationDao) {
+    public ReservationService(ReservationDao reservationDao, MemberDao memberDao) {
         this.reservationDao = reservationDao;
+        this.memberDao = memberDao;
     }
 
-    public ReservationResponse save(ReservationRequest reservationRequest) {
-        Reservation reservation = reservationDao.save(reservationRequest);
+    public ReservationResponse save(ReservationRequest reservationRequest, Member member) {
+        if (reservationRequest.getDate() == null || reservationRequest.getTheme() == null || reservationRequest.getTime() == null) {
+            throw new CustomException(ErrorCode.INVALID_RESERVATION_REQUEST);
+        }
 
-        return new ReservationResponse(reservation.getId(), reservationRequest.getName(), reservation.getTheme().getName(), reservation.getDate(), reservation.getTime().getValue());
+        String memberName = Optional.ofNullable(reservationRequest.getName())
+                .map(name -> {
+                    Member existingMember = memberDao.findByName(name);
+                    return existingMember.getName();
+                })
+                .orElse(member.getName());
+
+        ReservationRequest updatedRequest = new ReservationRequest(
+                memberName,
+                reservationRequest.getDate(),
+                reservationRequest.getTheme(),
+                reservationRequest.getTime()
+        );
+
+        Reservation reservation = reservationDao.save(updatedRequest);
+
+        return new ReservationResponse(
+                reservation.getId(),
+                reservation.getName(),
+                reservation.getTheme().getName(),
+                reservation.getDate(),
+                reservation.getTime().getValue());
     }
 
     public void deleteById(Long id) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,4 +8,5 @@ spring.datasource.url=jdbc:h2:mem:database
 #spring.jpa.ddl-auto=create-drop
 #spring.jpa.defer-datasource-initialization=true
 
-#roomescape.auth.jwt.secret= Yn2kjibddFAWtnPJ2AFlL8WXmohJMCvigQggaEypa5E=
+security.jwt.token.secret-key=Yn2kjibddFAWtnPJ2AFlL8WXmohJMCvigQggaEypa5E=
+security.jwt.token.expire-length=3600000

--- a/src/test/java/com/yourssu/roomescape/MissionStepTest.java
+++ b/src/test/java/com/yourssu/roomescape/MissionStepTest.java
@@ -34,5 +34,15 @@ public class MissionStepTest {
         String token = response.headers().get("Set-Cookie").getValue().split(";")[0].split("=")[1];
 
         assertThat(token).isNotBlank();
+
+        ExtractableResponse<Response> checkResponse = RestAssured.given().log().all()
+                .contentType(ContentType.JSON)
+                .cookie("token", token)
+                .when().get("/login/check")
+                .then().log().all()
+                .statusCode(200)
+                .extract();
+
+        assertThat(checkResponse.body().jsonPath().getString("name")).isEqualTo("어드민");
     }
 }

--- a/src/test/java/com/yourssu/roomescape/MissionStepTest.java
+++ b/src/test/java/com/yourssu/roomescape/MissionStepTest.java
@@ -2,7 +2,6 @@ package com.yourssu.roomescape;
 
 import com.yourssu.roomescape.auth.AuthService;
 import com.yourssu.roomescape.auth.LoginRequest;
-import com.yourssu.roomescape.jwt.TokenProvider;
 import com.yourssu.roomescape.reservation.ReservationResponse;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
@@ -86,5 +85,26 @@ public class MissionStepTest {
 
         assertThat(adminResponse.statusCode()).isEqualTo(201);
         assertThat(adminResponse.as(ReservationResponse.class).getName()).isEqualTo("브라운");
+    }
+
+    @Test
+    void 삼단계() {
+        LoginRequest loginRequest = new LoginRequest("brown@email.com", "password");
+        String brownToken = authService.login(loginRequest);
+
+        RestAssured.given().log().all()
+                .cookie("token", brownToken)
+                .get("/admin")
+                .then().log().all()
+                .statusCode(401);
+
+        loginRequest = new LoginRequest("admin@email.com", "password");
+        String adminToken = authService.login(loginRequest);
+
+        RestAssured.given().log().all()
+                .cookie("token", adminToken)
+                .get("/admin")
+                .then().log().all()
+                .statusCode(200);
     }
 }


### PR DESCRIPTION
### 1️⃣ **로그인**
**[JdbcTemplate] `queryForObject` vs `query` — 단일 조회와 다중 조회 차이**

| 메서드 | 사용 목적 | 조회 결과 없을 때 | 조회 결과 여러 개일 때 |
| --- | --- | --- | --- |
| `queryForObject` | 단일 객체 조회 | `EmptyResultDataAccessException` 발생 | `IncorrectResultSizeDataAccessException` 발생 |
| `query` | 다중 객체 조회 | 빈 리스트 반환 | 리스트로 반환 |
<br>

**예외처리 방안에 대한 고민**
- 방식 1. `queryForObject` 사용
    ```java
    public Member findByEmail(String email) {
            try {
                return jdbcTemplate.queryForObject(
                        "SELECT id, name, email, role FROM member WHERE email = ?",
                        (rs, rowNum) -> new Member(
                                rs.getLong("id"),
                                rs.getString("name"),
                                rs.getString("email"),
                                rs.getString("role")
                        ),
                        email
                );
            } catch (DataAccessException e) {
                throw new CustomException(ErrorCode.MEMBER_NOT_FOUND);
            }
        }
    ```
    - 단일 조회 의도가 코드상 명확.
    - 예외가 발생하는 경우 `try-catch`로 감싸야 함
    (단점 : 정상 흐름을 예외로 처리하여 코드 가독성 저하, 객체 생성 및 스택 추적 기록 등으로 성능 오버헤드 발생)

- 방식 2. `query` 사용
    
    ```java
    public Member findByEmail(String email) {
        List<Member> members = jdbcTemplate.query(
                "SELECT id, name, email, role FROM member WHERE email = ?",
                (rs, rowNum) -> new Member(
                        rs.getLong("id"),
                        rs.getString("name"),
                        rs.getString("email"),
                        rs.getString("role")
                ),
                email
        );
    
        if (members.isEmpty() || members.size() > 1) {
            throw new CustomException(ErrorCode.MEMBER_NOT_FOUND); 
        }
    
        return members.get(0);
    }
    ```
    - 예외를 발생시키지 않고, `List` 반환
    - 단일 조회임에도 리스트로 받아야 함.

- 결론
   - 우선 단일 조회임을 명확히 하기 위해 `queryForObject`를 선택했고, 그에 따른 예외 처리를 `try-catch` 구문으로 구현했습니다. 예외 발생 시 `CustomException`을 던지는 방식으로 처리했습니다.
   - 또한, 예외 처리 위치(DAO vs Service)에 대해 고민한 결과, 우선 코드 중복을 최소화하려는 목적에서 DAO 단에서 예외 처리를 바로 구현했습니다.

---

### 2️⃣ 로그인 리팩토링 - HandlerMethodArgumentResolver

`HandlerMethodArgumentResolver`
- Spring MVC에서 컨트롤러 메서드의 파라미터를 자동으로 주입해주는 커스텀 로직을 만들 때 사용하는 인터페이스
- 특정 어노테이션이 붙은 파라미터나 특정 타입을 자동으로 주입받게 할 수 있어서, 컨트롤러에서 반복되는 코드를 줄이고 책임을 분리할 수 있다.
- 주로 로그인 사용자 정보, 공통적인 인증/검증 객체 주입에 많이 사용된다.
<br>

**`supportsParameter`에서의 파라미터 처리 기준에 대한 고민**
1. `parameter.hasParameterAnnotation(LoginMember.class)` → 어노테이션이 붙은 경우 처리
2. `parameter.getParameterType().equals(LoginMember.class)` → 타입이 일치하는 경우 처리
3. 결론 : `@LoginMember` 어노테이션을 사용하면 해당 파라미터가 커스텀 주입임을 직관적으로 알 수 있어, 가독성이 좋다고 판단하여 어노테이션 기준으로 구현했습니다.
<br>

**참고 자료**
[Spring HandlerMethodArgumentResolver의 사용법과 동작원리](https://kingcjy.tistory.com/entry/Spring-HandlerMethodArgumentResolver%EC%9D%98-%EC%82%AC%EC%9A%A9%EB%B2%95%EA%B3%BC-%EB%8F%99%EC%9E%91%EC%9B%90%EB%A6%AC)

[[Spring] HandlerMethodArgumentResolver에 대해 알아보자](https://breakcoding.tistory.com/402)

[Spring | HandlerMethodArgumentResolver](https://velog.io/@tjddus0302/Spring-HandlerMethodArgumentResolver)

---

### 3️⃣ 관리자 기능 - `HandlerInterceptor`

`HandlerInterceptor`
- Spring MVC에서 URI 요청, 응답 시점을 가로채서 전/후 처리를 할 수 있게 해주는 인터페이스
- 요청이 컨트롤러에 전달되기 전, 후, 또는 예외가 발생했을 때 특정 작업을 수행할 수 있도록 도와준다.
- 주로 인증, 권한 검사, 로깅, 트랜잭션 관리, 성능 모니터링 등의 공통적인 작업을 컨트롤러와 분리하여 처리하는 데 사용된다.
<br>

**시도 : TokenExtractor 유틸리티 클래스 도입**
```java
public class TokenExtractor {

    private TokenExtractor() {
        // 객체 생성 방지
    }

    public static String extractTokenFromCookies(Cookie[] cookies) {
        if (cookies == null) {
            throw new CustomException(ErrorCode.COOKIE_NOT_FOUND);
        }

        return Arrays.stream(cookies)
                .filter(cookie -> "token".equals(cookie.getName()))
                .map(Cookie::getValue)
                .findFirst()
                .orElseThrow(() -> new CustomException(ErrorCode.TOKEN_NOT_FOUND));
    }
}
```
- 중복된 코드 제거: `Cookie`에서 토큰을 추출하는 로직이 3번 중복되어 유틸리티 클래스로 분리하였습니다.
- 객체 생성 방지: `TokenExtractor` 클래스의 생성자를 `private`으로 설정하여 인스턴스를 생성할 수 없도록 했습니다. 이를 통해 불필요한 객체 생성이 방지됩니다.
- `TokenExtractor.extractTokenFromCookies()`로 인스턴스 없이 바로 호출이 가능해져 코드가 간결해집니다.
<br>

**HandlerInterceptor에서의 예외처리에 대한 고민** 
1. 문제 : `HandlerInterceptor`에서 예외를 `@RestControllerAdvice`가 처리하지 못하는 문제가 발생
2. 원인 : `HandlerInterceptor`가 컨트롤러 메서드 실행 전에 요청을 가로채기 때문에, 예외가 발생했을 때 Spring MVC의 예외 처리 메커니즘이 작동하지 않는다.
4. 해결 : 예외를 `HandlerInterceptor` 내에서 처리하고, `HttpServletResponse`를 사용하여 직접 응답을 보내는 방식으로 처리
(해당 부분은 추가로 학습할 예정입니다.)
<br>

**참고 자료**
[Spring HandlerInterceptor를 활용하여 컨트롤러 중복 코드 제거하기](https://hudi.blog/spring-handler-interceptor/)